### PR TITLE
Add optional parameter keepOffset to toISOString

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -542,7 +542,7 @@ declare namespace moment {
 
     toArray(): number[];
     toDate(): Date;
-    toISOString(): string;
+    toISOString(keepOffset?: boolean): string;
     inspect(): string;
     toJSON(): string;
     unix(): number;


### PR DESCRIPTION
Update the typescript definition file to include the optional parameter keepOffset which was introduced in 2.20.0